### PR TITLE
Bumps org.zalando.stups.tokens to latest version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>org.zalando.stups</groupId>
             <artifactId>tokens</artifactId>
-            <version>0.9.9</version>
+            <version>0.11.0-beta-2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Latest version of `org.zalando.stups.tokens` gives support of tokens generated in new infrastructure in Zalando.