### PR TITLE
Add Zalando-internal Dockerfile to support non-CDP build systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ FROM registry.opensource.zalan.do/stups/openjdk:latest
 EXPOSE 8086
 
 COPY target/zmon-data-service-1.0-SNAPSHOT.jar /zmon-data-service.jar
+COPY target/scm-source.json /
 
 CMD java $JAVA_OPTS $(java-dynamic-memory-opts) -jar /zmon-data-service.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,5 @@ FROM registry.opensource.zalan.do/stups/openjdk:latest
 EXPOSE 8086
 
 COPY target/zmon-data-service-1.0-SNAPSHOT.jar /zmon-data-service.jar
-COPY target/scm-source.json /
 
 CMD java $JAVA_OPTS $(java-dynamic-memory-opts) -jar /zmon-data-service.jar

--- a/Dockerfile.zalando
+++ b/Dockerfile.zalando
@@ -1,0 +1,9 @@
+# Dockerfile for internal local/staging Zalando builds:
+FROM registry.opensource.zalan.do/stups/openjdk:latest
+
+EXPOSE 8086
+
+COPY target/zmon-data-service-1.0-SNAPSHOT.jar /zmon-data-service.jar
+COPY target/scm-source.json /
+
+CMD java $JAVA_OPTS $(java-dynamic-memory-opts) -jar /zmon-data-service.jar

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -8,23 +8,20 @@ pipeline:
           apt-get install -y \
           openjdk-8-* \
           maven \
-          git \
-          python3.5 \
-          python3-pip
+          git
           curl -fLOsS https://delivery.cloud.zalando.com/utils/ensure-docker && sh ensure-docker && rm ensure-docker
 
       - desc: "Build maven package"
         cmd: |
           ./mvnw clean package
 
-          # Our Dockerfiles still need to be compatible with Jenkins deployments and local builds:
-          pip3 install --upgrade scm-source
-          scm-source -f target/scm-source.json
-
       - desc: "Push Docker Image"
         cmd: |
-          if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
-            AGENT_IMAGE=registry-write.opensource.zalan.do/zmon/zmon-data-service:${CDP_BUILD_VERSION}
+          IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
+          if [[ ${IS_PR_BUILD} != "true" ]]
+          then
+            RELEASE_VERSION=$(git describe --tags --always --dirty)
+            AGENT_IMAGE=registry-write.opensource.zalan.do/zmon/zmon-data-service:${RELEASE_VERSION}
             docker build --tag "$AGENT_IMAGE" .
             docker push "$AGENT_IMAGE"
           else

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -8,22 +8,26 @@ pipeline:
           apt-get install -y \
           openjdk-8-* \
           maven \
-          git
+          git \
+          python3.5 \
+          python3-pip
           curl -fLOsS https://delivery.cloud.zalando.com/utils/ensure-docker && sh ensure-docker && rm ensure-docker
 
       - desc: "Build maven package"
         cmd: |
           ./mvnw clean package
 
+          # Our Dockerfiles still need to be compatible with Jenkins deployments and local builds:
+          pip3 install --upgrade scm-source
+          scm-source -f target/scm-source.json
+
       - desc: "Push Docker Image"
         cmd: |
-          IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
-          if [[ ${IS_PR_BUILD} != "true" ]]
-          then
-            RELEASE_VERSION=$(git describe --tags --always --dirty)
-            AGENT_IMAGE=registry-write.opensource.zalan.do/zmon/zmon-data-service:${RELEASE_VERSION}
+          if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
+            AGENT_IMAGE=registry-write.opensource.zalan.do/zmon/zmon-data-service:${CDP_BUILD_VERSION}
+            docker build --tag "$AGENT_IMAGE" .
+            docker push "$AGENT_IMAGE"
           else
             AGENT_IMAGE=registry-write.opensource.zalan.do/zmon/zmon-data-service:${CDP_BUILD_VERSION}
+            docker build --tag "$AGENT_IMAGE" .
           fi
-          docker build --tag "$AGENT_IMAGE" .
-          docker push "$AGENT_IMAGE"


### PR DESCRIPTION
Edit: to keep production OSS images free of anything Z-specifc there can be a separate, internal Dockerfile for such builds.  This would allow all non-CDP build workflows without modifying delivery.yaml or the master Dockerfile.

---
Original PR:

The delivery.yaml for CDP, and internal deployment manifests, as currently configured, are now requiring the usage of our public docker repository for all staging and test builds.  With this change we will only push production images to our public repository, and keep our PR and test images internal.

While CDP allows for passing of docker image names as a parameter into the deployment manifests, the internal Jenkins used for staging builds does not - it can only use whatever is hardcoded into the manifests.  However since we do not use CDP deployment in any stage, we can solve that problem later.  Taking a dependency on CDP for builds-only in the meantime only adds overhead (public Github PRs required), and delays (Github PR update -> CDP full build from scratch), overhead that gets in the way of rapid-feedback cycles during development.

To allow both worlds in the meantime, the scm-source step had to be added back to the Dockerfile.  CDP will ignore it for its builds.  Jenkins still requires it.  A concurrent PR on our internal deployment repos will follow, and other components as they are touched next.