### PR TITLE
Reverted the spring opentracing contrib lib to version 0.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-spring-cloud-starter</artifactId>
-            <version>0.1.14</version>
+            <version>0.1.6</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing.contrib</groupId>


### PR DESCRIPTION
Reverted the spring opentracing contrib lib to version 0.1.6
as the 0.1.14 is not compatible with Springboot 1.4.4.release