### PR TITLE
Fix opentracing contrib version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-spring-cloud-starter</artifactId>
-            <version>0.1.14</version>
+            <version>0.1.6</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing.contrib</groupId>


### PR DESCRIPTION
Revert to version ``0.1.6`` to avoid Full GCs

Signed-off-by: Mohab Usama <mohab.abdelhameed@zalando.de>