### PR TITLE
Update fluent-hc library to fix bug where config is ignored

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-spring-cloud-starter</artifactId>
-            <version>0.1.6</version>
+            <version>0.2.4</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.3.6</version>
+            <version>4.5.7</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/de/zalando/zmon/dataservice/proxies/checks/CachingCheckService.java
+++ b/src/main/java/de/zalando/zmon/dataservice/proxies/checks/CachingCheckService.java
@@ -80,6 +80,7 @@ public class CachingCheckService implements ChecksService {
 
     @Scheduled(fixedRate = 60000)
     public void refreshData() {
+        log.info("refreshing checks and alerts");
         try {
             String nextCheckLastModified = service.allActiveCheckDefinitionsLastModified(Optional.of(wrapper.get()), "");
 


### PR DESCRIPTION
In #105 HttpClientFactory was added which allowed request timeouts to be overwritten. However, due to bug in fluent-hc (see https://issues.apache.org/jira/browse/HTTPCLIENT-1645) `new Request` set its own RequestConfig (with default settings like infinite timeout) and `Executor` used it instead.