### PR TITLE
fix result size warnings

### DIFF
--- a/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
+++ b/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
@@ -151,6 +151,7 @@ public class KairosDBStore {
 
                 fillFlatValueMap(values, "", cd.checkResult.get("value"));
 
+                int cdResultSize = 0;
                 for (Map.Entry<String, NumericNode> e : values.entrySet()) {
                     DataPoint p = new DataPoint();
                     p.name = timeSeries;
@@ -192,10 +193,11 @@ public class KairosDBStore {
 
                     p.datapoints.add(arrayNode);
                     points.add(p);
+                    cdResultSize += 1
                 }
 
-                if (points.size() > resultSizeWarning) {
-                    LOG.warn("result size warning: check={} data-points={} entity={}", cd.checkId, points.size(), cd.entityId);
+                if (cdResultSize > resultSizeWarning) {
+                    LOG.warn("result size warning: check={} data-points={} entity={}", cd.checkId, cdResultSize, cd.entityId);
                 }
             }
 

--- a/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
+++ b/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
@@ -193,7 +193,7 @@ public class KairosDBStore {
 
                     p.datapoints.add(arrayNode);
                     points.add(p);
-                    cdResultSize += 1
+                    cdResultSize += 1;
                 }
 
                 if (cdResultSize > resultSizeWarning) {


### PR DESCRIPTION
the data may come in batches per check id for different entities,
the points is all points for the full batch which is not the number of
data points for the check result for one entity