### PR TITLE
fix proxy error handling

### DIFF
--- a/src/main/java/de/zalando/zmon/dataservice/proxies/kairosdb/KairosdbProxy.java
+++ b/src/main/java/de/zalando/zmon/dataservice/proxies/kairosdb/KairosdbProxy.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Writer;
+import java.util.Arrays;
 
 @Controller
 @RequestMapping(value = "/kairosdb-proxy/")
@@ -74,6 +75,7 @@ public class KairosdbProxy {
                     throw new ClientProtocolException("Response contains no content");
                 }
                 response.setStatus(status.getStatusCode());
+                Arrays.stream(res.getAllHeaders()).forEach(h -> response.setHeader(h.getName(), h.getValue()));
                 final InputStreamReader reader = new InputStreamReader(entity.getContent());
                 return CharStreams.toString(reader);
             });

--- a/src/main/java/de/zalando/zmon/dataservice/proxies/kairosdb/KairosdbProxy.java
+++ b/src/main/java/de/zalando/zmon/dataservice/proxies/kairosdb/KairosdbProxy.java
@@ -4,9 +4,13 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.io.CharStreams;
 import de.zalando.zmon.dataservice.DataServiceMetrics;
 import de.zalando.zmon.dataservice.config.DataServiceConfigProperties;
 import de.zalando.zmon.dataservice.data.HttpClientFactory;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
@@ -22,6 +26,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.Writer;
 
 @Controller
@@ -62,12 +67,18 @@ public class KairosdbProxy {
         }
 
         try {
-            String data = executor.execute(request).returnContent().toString();
+            final String data = executor.execute(request).handleResponse(res -> {
+                final StatusLine status = res.getStatusLine();
+                HttpEntity entity = res.getEntity();
+                if (entity == null) {
+                    throw new ClientProtocolException("Response contains no content");
+                }
+                response.setStatus(status.getStatusCode());
+                final InputStreamReader reader = new InputStreamReader(entity.getContent());
+                return CharStreams.toString(reader);
+            });
             response.setContentType("application/json");
             writer.write(data);
-        } catch (HttpResponseException hre) {
-            log.warn("KairosDB returned non 2xx response: {}", hre.getMessage());
-            response.sendError(hre.getStatusCode());
         } catch (IOException e) {
             log.warn("I/O error while calling KairosDB: {}", e.getMessage());
             response.sendError(HttpServletResponse.SC_BAD_GATEWAY);


### PR DESCRIPTION
Only the KDB query datapoints/query, and datapoints/query/tags, and the read /metricnames endpoints are supported. 
In case of any non 2xx response, HTTP status code is proxied to the client, but that’s it. Response payload and headers are lost.
**Solution**: like for ZMON Controller: propagate w/o modification
