### PR TITLE
Don't store job related metrics by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_script:
   - pip install --user codecov
 
 script:
+  - jdk_switcher use oraclejdk8
   - mvn clean verify
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 
 sudo: true
 
+dist: trusty
+
 jdk:
   - oraclejdk8
 

--- a/src/main/java/de/zalando/zmon/dataservice/DataServiceMetrics.java
+++ b/src/main/java/de/zalando/zmon/dataservice/DataServiceMetrics.java
@@ -67,6 +67,11 @@ public class DataServiceMetrics {
     private final Meter workerResultsBatchedCount;
     private final Meter workerResultsEmptyCount;
 
+    private final Meter jobMetricsTotal;
+    private final Meter jobMetricsIngestionDropped;
+    private final Meter jobMetricsIngestionTotal;
+    private final Meter nonSampledDropped;
+
     // @Autowired
     public DataServiceMetrics(MetricRegistry metrics) {
         this.metrics = metrics;
@@ -85,6 +90,10 @@ public class DataServiceMetrics {
         this.workerResultsCount = metrics.meter("data-service.worker-results");
         this.workerResultsBatchedCount = metrics.meter("data-service.worker-results-batched");
         this.workerResultsEmptyCount = metrics.meter("data-service.worker-results-empty");
+        this.jobMetricsTotal = metrics.meter("data-service.job-metrics.total");
+        this.jobMetricsIngestionDropped = metrics.meter("data-service.job-metrics-ingestion.dropped");
+        this.jobMetricsIngestionTotal = metrics.meter("data-service.job-metrics-ingestion.total");
+        this.nonSampledDropped = metrics.meter("data-service.non-sampled.dropped");
     }
 
     public MetricRegistry getMetricRegistry() {
@@ -215,4 +224,10 @@ public class DataServiceMetrics {
     public void updateAlertDurations(long duration) {
         alertDurations.update(duration);
     }
+
+    public void incJobMetricsTotal(long c) { jobMetricsTotal.mark(c);}
+    public void incJobMetricsIngestionDropped(long c) { jobMetricsIngestionDropped.mark(c);}
+    public void incJobMetricsIngestionTotal(long c) { jobMetricsIngestionTotal.mark(c);}
+
+    public void incNonSampledDropped(long c) { nonSampledDropped.mark(c);}
 }

--- a/src/main/java/de/zalando/zmon/dataservice/config/DataServiceConfigProperties.java
+++ b/src/main/java/de/zalando/zmon/dataservice/config/DataServiceConfigProperties.java
@@ -40,6 +40,7 @@ public class DataServiceConfigProperties {
     private boolean logKairosdbErrors = false;
 
     private boolean trackCheckRate = false;
+    private boolean writeAllJobMetrics = true;
 
     private List<Integer> actuatorMetricChecks = new ArrayList<>();
 
@@ -103,6 +104,14 @@ public class DataServiceConfigProperties {
 
     public void setTrackCheckRate(boolean trackCheckRate) {
         this.trackCheckRate = trackCheckRate;
+    }
+
+    public void setWriteAllJobMetrics(boolean writeAllJobMetrics) {
+        this.writeAllJobMetrics = writeAllJobMetrics;
+    }
+
+    public boolean isWriteAllJobMetrics() {
+        return writeAllJobMetrics;
     }
 
     public Map<String, AsyncExecutorProperties> getAsyncExecutors() {

--- a/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
+++ b/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
@@ -185,12 +185,14 @@ public class KairosDBStore {
                 }
 
                 boolean isJobRelated = false;
-                if (isJobRelatedEntity(cd.entity)) {
-                    metrics.incJobMetricsIngestionTotal(1);
-                    isJobRelated = true;
-                    if (!jobMetricsAreStored(cd.entity, cd.checkId)) {
-                        metrics.incJobMetricsIngestionDropped(1);
-                        continue;
+                if (!config.isWriteAllJobMetrics()) {
+                    if (isJobRelatedEntity(cd.entity)) {
+                        metrics.incJobMetricsIngestionTotal(1);
+                        isJobRelated = true;
+                        if (!jobMetricsAreStored(cd.entity, cd.checkId)) {
+                            metrics.incJobMetricsIngestionDropped(1);
+                            continue;
+                        }
                     }
                 }
 

--- a/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
+++ b/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
@@ -31,7 +31,7 @@ public class KairosDBStore {
 
     private final DataPointsQueryStore dataPointsQueryStore;
 
-    private final String jobMetricStoredAnnotation = "zmon.io/job-metric-stored";
+    private final String jobMetricStoredAnnotation = "zalando.org/zmon-job-metric-stored";
 
     private final Set<String> entityTagFields;
     // adding alias,account_alias,cluster_alias due to legacy, and should be exclusive anyways

--- a/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
+++ b/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.validation.constraints.Null;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.*;
@@ -140,7 +141,13 @@ public class KairosDBStore {
     }
 
     private boolean metricsAreStored(Map<String, String> entity, int checkId) {
+        if (entity == null || entity.isEmpty()) {
+            return true;
+        }
         String entityType = entity.get("type");
+        if (entityType == null) {
+            return true;
+        }
         if (!entityType.equals("kube_pod") && !entityType.equals("kube_pod_container")) {
             return true;
         }
@@ -173,7 +180,7 @@ public class KairosDBStore {
                 }
 
                 if (!metricsAreStored(cd.entity, cd.checkId)) {
-                    continue;
+                     continue;
                 }
 
                 metrics.incWorkerResultsBatchedCount(1);

--- a/src/test/java/de/zalando/zmon/dataservice/data/KairosDbStoreTest.java
+++ b/src/test/java/de/zalando/zmon/dataservice/data/KairosDbStoreTest.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static de.zalando.zmon.dataservice.data.Fixture.buildWorkerResult;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
@@ -44,7 +45,7 @@ public class KairosDbStoreTest extends AbstractControllerTest {
     @Test
     public void writeWorkerResult() {
         KairosDBStore kairosDb = new KairosDBStore(config, metrics, dataPointsQueryStore);
-        kairosDb.store(Fixture.buildWorkerResult());
+        kairosDb.store(buildWorkerResult());
         verify(dataPointsQueryStore, atMost(1)).store(anyString());
         verify(metrics, never()).markKairosError();
         verify(metrics, never()).markKairosHostErrors(anyLong());


### PR DESCRIPTION
Check job related pods and containers for the "zmon.io/job-metric-stored"
annotation and ignore those where it's not set.

Signed-off-by: Hanno Hecker <hanno@zalando.de>