### PR TITLE
add write-all-job-metrics to config

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -17,6 +17,7 @@ dataservice:
   oauth2-token-info-url: ${TOKENINFO_URL:http://localhost:10080/oauth2/tokeninfo}
   kairosdb-write-urls:
     - ["http://localhost:8083"]
+  write-all-job-metrics: true
   oauth2-scopes:
     getApi: "#oauth2.hasScope('zmon_data.read_all') || (#oauth2.hasScope('uid') && #oauth2.hasRealm('/employees'))"
     putApi: "#oauth2.hasScope('zmon_data.read_all') || (#oauth2.hasScope('uid') && #oauth2.hasRealm('/employees'))"


### PR DESCRIPTION
enables #131 since write-all-job-metrics config can't be set using environment unless it has been added to yaml config