### PR TITLE
Job metrics - update to worker results

### DIFF
--- a/src/main/java/de/zalando/zmon/dataservice/data/CheckData.java
+++ b/src/main/java/de/zalando/zmon/dataservice/data/CheckData.java
@@ -25,4 +25,8 @@ public class CheckData {
     public Map<String, AlertData> alerts = new HashMap<>(0);
     @JsonProperty("is_sampled")
     public boolean isSampled = true;
+    @JsonProperty("job_metric")
+    public boolean isJobMetric = false;
+    @JsonProperty("store_job_metric")
+    public boolean isStoreJobMetric = false;
 }


### PR DESCRIPTION
for the job-related entities - here only a subset of the entity is available