### PR TITLE
Add critical check result size metrics per account

### DIFF
--- a/src/main/java/de/zalando/zmon/dataservice/config/DataServiceConfigProperties.java
+++ b/src/main/java/de/zalando/zmon/dataservice/config/DataServiceConfigProperties.java
@@ -94,6 +94,7 @@ public class DataServiceConfigProperties {
     private Map<String, AsyncExecutorProperties> asyncExecutors = new HashMap<>();
 
     private int resultSizeWarning = 2000;
+    private int resultSizeMetricThreshold = 2000;
     private long connectionsTimeToLive = 2 * 60 * 1000;
 
     private Map<String, Object> versionConfig = null;
@@ -128,6 +129,14 @@ public class DataServiceConfigProperties {
 
     public void setResultSizeWarning(int resultSizeWarning) {
         this.resultSizeWarning = resultSizeWarning;
+    }
+
+    public int getResultSizeMetricThreshold() {
+        return resultSizeMetricThreshold;
+    }
+
+    public void setResultSizeMetricThreshold(int resultSizeMetricThreshold) {
+        this.resultSizeMetricThreshold = resultSizeMetricThreshold;
     }
 
     public boolean isProxyControllerOauth2() {

--- a/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
+++ b/src/main/java/de/zalando/zmon/dataservice/data/KairosDBStore.java
@@ -71,6 +71,7 @@ public class KairosDBStore {
 
     private final DataServiceMetrics metrics;
     private final int resultSizeWarning;
+    private final int resultSizeMetricThreshold;
     private MetricTiers metricTiers;
 
     private static class DataPoint {
@@ -89,6 +90,7 @@ public class KairosDBStore {
         this.config = config;
         this.dataPointsQueryStore = dataPointsQueryStore;
         this.resultSizeWarning = config.getResultSizeWarning();
+        this.resultSizeMetricThreshold = config.getResultSizeMetricThreshold();
         this.metricTiers = metricTiers;
 
         if (null == config.getKairosdbTagFields() || config.getKairosdbTagFields().size() == 0) {
@@ -249,6 +251,10 @@ public class KairosDBStore {
 
                 if (cdResultSize > resultSizeWarning) {
                     LOG.warn("result size warning: check={} data-points={} job-related={} entity={} tags={}", cd.checkId, cdResultSize, isJobRelated, cd.entityId, getEntityTags(cd.entity));
+                }
+
+                if (cdResultSize > resultSizeMetricThreshold) {
+                    metrics.markCriticalCheck(cd.checkId, wr.account, cdResultSize);
                 }
 
                 if (cd.checkId == config.getCheckMetricsWatchId() && Math.random() <= 0.1) {


### PR DESCRIPTION
This should enable us to see a breakdown of ingested check results with
critical number of data points per account.