### PR TITLE
add captures to eventlog / alert history

### DIFF
--- a/src/main/java/de/zalando/zmon/dataservice/ZMonEventType.java
+++ b/src/main/java/de/zalando/zmon/dataservice/ZMonEventType.java
@@ -9,8 +9,8 @@ public enum ZMonEventType implements EventType {
     // worker events
     ALERT_STARTED(0x34001, "checkId", "alertId", "value"),
     ALERT_ENDED(0x34002, "checkId", "alertId", "value"),
-    ALERT_ENTITY_STARTED(0x34003, "checkId", "alertId", "value", "entity"),
-    ALERT_ENTITY_ENDED(0x34004, "checkId", "alertId", "value", "entity"),
+    ALERT_ENTITY_STARTED(0x34003, "checkId", "alertId", "value", "entity", "captures"),
+    ALERT_ENTITY_ENDED(0x34004, "checkId", "alertId", "value", "entity", "captures"),
     DOWNTIME_STARTED(0x34005, "alertId", "entity", "startTime", "endTime", "userName", "comment"),
     DOWNTIME_ENDED(0x34006, "alertId", "entity", "startTime", "endTime", "userName", "comment"),
 

--- a/src/main/java/de/zalando/zmon/dataservice/data/RedisDataStore.java
+++ b/src/main/java/de/zalando/zmon/dataservice/data/RedisDataStore.java
@@ -68,9 +68,9 @@ public class RedisDataStore {
         }
 
         if (ad.active && ad.changed) {
-            eventLogger.log(ZMonEventType.ALERT_ENTITY_STARTED, checkId, ad.alert_id, checkValue, entity);
+            eventLogger.log(ZMonEventType.ALERT_ENTITY_STARTED, checkId, ad.alert_id, checkValue, entity, ad.captures);
         } else if (!ad.active && ad.changed) {
-            eventLogger.log(ZMonEventType.ALERT_ENTITY_ENDED, checkId, ad.alert_id, checkValue, entity);
+            eventLogger.log(ZMonEventType.ALERT_ENTITY_ENDED, checkId, ad.alert_id, checkValue, entity, ad.captures);
         }
     }
 


### PR DESCRIPTION
this eases finding the alert cause with huge results or computed alert
values - alert authors need to capture the desired values to see them
in the alert history

Signed-off-by: Hanno Hecker <hanno@zalando.de>